### PR TITLE
Removed local folder dependency from plugin

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
     }
   },
   "dependencies": {
-    "nativescript-charts": "file:///D:\\Android\\AndroidPlugins\\MPAndroidChart\\myplugin",
+    "nativescript-charts": "..",
     "nativescript-dev-typescript": "^0.3.2",
     "tns-core-modules": "^2.5.0",
     "tns-platform-declarations": "^2.3.0"

--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,6 @@
     }
   },
   "dependencies": {
-    "nativescript-charts": "file:///D:\\Android\\AndroidPlugins\\MPAndroidChart\\myplugin",
     "nativescript-dev-typescript": "^0.3.2",
     "tns-core-modules": "^2.5.0",
     "tns-platform-declarations": "^2.3.0"


### PR DESCRIPTION
The dependency for the plugin itself has been removed with reference to the local folder, so that it can be added when running the `npm run setup` script